### PR TITLE
README.rdoc -> README.md

### DIFF
--- a/authy.gemspec
+++ b/authy.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
     "Gemfile",
     "Gemfile.lock",
     "LICENSE.txt",
-    "README.rdoc",
+    "README.md",
     "Rakefile",
     "VERSION",
     "authy.gemspec",


### PR DESCRIPTION
Fix Bundler warning `["README.rdoc"] are not files`.
