### PR TITLE
Specify version of httpclient dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem 'httpclient'
+gem 'httpclient', ">= 2.2.6"
 
 group :development do
   gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  httpclient
+  httpclient (>= 2.2.6)
   jeweler
   pry
   rdoc

--- a/authy.gemspec
+++ b/authy.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<httpclient>, [">= 0"])
+      s.add_runtime_dependency(%q<httpclient>, [">= 2.2.6"])
       s.add_development_dependency(%q<rspec>, [">= 0"])
       s.add_development_dependency(%q<pry>, [">= 0"])
       s.add_development_dependency(%q<yard>, [">= 0"])


### PR DESCRIPTION
Not specifying which version of httpclient you require can cause issues if bundler loads a gem version under 2.2.6, which does work with authy.
