### PR TITLE
Allow API key setting via ENV variable

### DIFF
--- a/lib/authy/config.rb
+++ b/lib/authy/config.rb
@@ -5,7 +5,7 @@ module Authy
     end
 
     def api_key
-      @api_key
+      @api_key || ENV["AUTHY_API_KEY"]
     end
 
     def api_uri=(uri)

--- a/spec/authy/api_spec.rb
+++ b/spec/authy/api_spec.rb
@@ -50,7 +50,7 @@ describe "Authy::API" do
       response = Authy::API.verify(:token => 'invalid_token', :id => @user.id)
 
       response.should be_kind_of(Authy::Response)
-      response.ok?.should be_false
+      response.ok?.should be_falsy
       response.errors['message'].should == 'Token is invalid.'
     end
 

--- a/spec/authy/config_spec.rb
+++ b/spec/authy/config_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe "Authy" do
+  describe "api_key" do
+    around do
+      Authy.api_key = nil
+      ENV["AUTHY_API_KEY"] = nil
+    end
+
+    it "should set and read instance variable" do
+      Authy.api_key = "foo"
+      Authy.api_key.should == "foo"
+    end
+
+    it "should fallback to ENV variable" do
+      ENV["AUTHY_API_KEY"] = "bar"
+      Authy.api_key.should == "bar"
+    end
+  end
+
+  describe "api_url" do
+    around do
+      Authy.api_url = nil
+    end
+
+    it "should set and read instance variable" do
+      Authy.api_url = "https://example.com/"
+      Authy.api_url.should == "https://example.com/"
+    end
+
+    it "should fallback to default value" do
+      Authy.api_url = nil
+      Authy.api_url.should be_present
+    end
+  end
+end

--- a/spec/authy/response_spec.rb
+++ b/spec/authy/response_spec.rb
@@ -14,11 +14,11 @@ describe "Authy::Response" do
   end
 
   it "should be ok if the return code is 200" do
-    @response.ok?.should be_true
+    @response.ok?.should be_truthy
 
     @fake_response.status = 401
     @response = Authy::Response.new(@fake_response)
-    @response.ok?.should be_false
+    @response.ok?.should be_falsy
   end
 
   it "should return the error message" do


### PR DESCRIPTION
Thus we can remove the following section of authy/authy-devise.

> First create an initializer in `config/initializer/authy.rb`

> ```ruby
Authy.api_key = ENV['AUTHY_API_KEY'] || 'your_authy_api_key'
Authy.api_uri = 'https://api.authy.com/'
```