### PR TITLE
Fix specs

### DIFF
--- a/spec/authy/api_spec.rb
+++ b/spec/authy/api_spec.rb
@@ -50,7 +50,7 @@ describe "Authy::API" do
       response = Authy::API.verify(:token => 'invalid_token', :id => @user.id)
 
       response.should be_kind_of(Authy::Response)
-      response.ok?.should be_false
+      response.ok?.should be false
       response.errors['message'].should == 'Token is invalid.'
     end
 

--- a/spec/authy/response_spec.rb
+++ b/spec/authy/response_spec.rb
@@ -14,11 +14,11 @@ describe "Authy::Response" do
   end
 
   it "should be ok if the return code is 200" do
-    @response.ok?.should be_true
+    @response.ok?.should be true
 
     @fake_response.status = 401
     @response = Authy::Response.new(@fake_response)
-    @response.ok?.should be_false
+    @response.ok?.should be false
   end
 
   it "should return the error message" do


### PR DESCRIPTION
Hi, I forked this repo and ran the specs, but then I received the following errors:

<pre>
Failures:

  1) Authy::Response should be ok if the return code is 200
     Failure/Error: @response.ok?.should be_true
       expected true to respond to `true?`
     # ./spec/authy/response_spec.rb:17:in `block (2 levels) in <top (required)>'

  2) Authy::API verificating tokens should fail to validate a given token if the user is not registered
     Failure/Error: response.ok?.should be_false
       expected false to respond to `false?`
     # ./spec/authy/api_spec.rb:53:in `block (3 levels) in <top (required)>'
</pre>


This PR fix this problem.
