### PR TITLE
Allow Authy::API.register_user to take a :send_install_link_via_sms option

### DIFF
--- a/lib/authy/api.rb
+++ b/lib/authy/api.rb
@@ -15,7 +15,7 @@ module Authy
 
     def self.register_user(attributes)
       api_key = attributes.delete(:api_key)
-      send_install_link_via_sms = attributes.delete(:send_install_link_via_sms) { false }
+      send_install_link_via_sms = attributes.delete(:send_install_link_via_sms) { true }
       params = {
         :user => attributes,
         :api_key => api_key || Authy.api_key,

--- a/lib/authy/api.rb
+++ b/lib/authy/api.rb
@@ -15,9 +15,11 @@ module Authy
 
     def self.register_user(attributes)
       api_key = attributes.delete(:api_key)
+      send_install_link_via_sms = attributes.delete(:send_install_link_via_sms) { false }
       params = {
         :user => attributes,
-        :api_key => api_key || Authy.api_key
+        :api_key => api_key || Authy.api_key,
+        :send_install_link_via_sms => send_install_link_via_sms
       }
 
       url = "#{Authy.api_uri}/protected/json/users/new"

--- a/spec/authy/api_spec.rb
+++ b/spec/authy/api_spec.rb
@@ -40,6 +40,22 @@ describe "Authy::API" do
       user.errors['message'].should =~ /invalid api key/i
     end
 
+    it "should allow overriding send_install_link_via_sms default" do
+      user = Authy::API.register_user(
+        :email => generate_email,
+        :cellphone => generate_cellphone,
+        :country_code => 1,
+        :send_install_link_via_sms => false #default is true. See http://docs.authy.com/totp.html#totp-api
+      )
+
+      user.should be_kind_of(Authy::Response)
+
+      user.should be_kind_of(Authy::User)
+      user.should_not be_nil
+      user.id.should_not be_nil
+      user.id.should be_kind_of(Integer)
+    end
+
   end
 
   describe "verificating tokens" do


### PR DESCRIPTION
Per the documentation in http://docs.authy.com/totp.html#totp-api

We are using the `authy-devise` gem for our production Rails app, and we want the option to not send users the install link via SMS when they register for authy.

Rather than fork both gems to pass in one flag to one request, we would love this to be merged!

We've attempted a spec, but given the existing structure of `Authy::API.register_user`, it doesn't appear that the client will fail when passed an option that it doesn't know how to deal with. Testing that the SMS sent doesn't have the link in question (ala an acceptance spec) seems outside of the scope of this PR.

Please let us know if there's anything else we can do to help! We love using this service and are happy to contribute toward its further open-source development.

Best,
Tom Reznick
Software Engineer
Continuity

cc @alexwilkinson