### PR TITLE
Use hash rocket syntax for consistency

### DIFF
--- a/lib/authy/api.rb
+++ b/lib/authy/api.rb
@@ -11,7 +11,7 @@ module Authy
     include Authy::URL
 
     extend HTTPClient::IncludeClient
-    include_http_client(agent_name: USER_AGENT)
+    include_http_client(:agent_name => USER_AGENT)
 
     def self.register_user(attributes)
       api_key = attributes.delete(:api_key)

--- a/lib/authy/onetouch.rb
+++ b/lib/authy/onetouch.rb
@@ -28,7 +28,7 @@ module Authy
         return invalid_response("Invalid parameters: #{e.message}")
       end
 
-      params = { message: message[0, MAX_STRING_SIZE] }
+      params = { :message => message[0, MAX_STRING_SIZE] }
       params[:details]           = details unless details.nil?
       params[:hidden_details]    = hidden_details unless hidden_details.nil?
       params[:logos]             = logos unless logos.nil?
@@ -64,7 +64,7 @@ module Authy
 
         # We ignore any additional parameter on the logos, and truncate
         # string size to the maximum allowed.
-        { res: res[0, MAX_STRING_SIZE], url: url[0, MAX_STRING_SIZE] }
+        { :res => res[0, MAX_STRING_SIZE], :url => url[0, MAX_STRING_SIZE] }
       end
     end
   end


### PR DESCRIPTION
Since the gemspec doesn't list a required ruby version, I figured I'd make these changes to ensure compatibility with older rubies.

No new tests since this is a purely syntactic change.
