### PR TITLE
Support generating qr code for other authenticator apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,22 @@ This call will be ignored if the user is using the Authy Mobile App. If you ensu
     response = Authy::API.request_phone_call(:id => user.authy_id, :force => true)
 ```
 
+## Requesting QR code for authenticator apps like Google Authenticator
+
+`Authy::API.request_qr_code` takes authy_id that you want to deliver the qr code. This requires **Generic authenticator tokens** to be enabled in Authy console setting. Optinally, you can provide `qr_size` as a number to decide the output of qr image (For example: `qr_size: 400` will returns a 400x400 image) and `label` as a custom label to be shown by the authenticator app.  
+
+```ruby
+    response = Authy::API.request_qr_code(id: user.authy_id, qr_size: 500, label: "My Example App")
+    if response.ok?
+      # qr code was generated
+    else
+      response.errors
+    end
+
+    # You can access the iamge link with
+    link = response.qr_code
+```
+
 ## Deleting users
 
 `Authy::API.delete_user` takes the authy_id of the user that you want to remove from your app.

--- a/lib/authy/api.rb
+++ b/lib/authy/api.rb
@@ -66,6 +66,25 @@ module Authy
 
     # options:
     # :id user id
+    # :qr_size qr size
+    # :qr_label context for qr code
+    def self.request_qr_code(params)
+      user_id = params.delete(:id) || params.delete('id')
+      qr_size = params.delete(:qr_size) || params.delete('qr_size') || 300
+      qr_label = params.delete(:qr_label) || params.delete('qr_label') || ""
+
+      return invalid_response('User id is invalid') unless is_digit?(user_id)
+      return invalid_response('Qr image size is invalid') unless is_digit?(qr_size)
+
+      response = post_request("protected/json/users/:user_id/secret" ,params.merge({
+        "user_id" => user_id,
+        "qr_size" => qr_size,
+        "label" => qr_label
+      }))
+    end
+
+    # options:
+    # :id user id
     # :force force phone_call
     def self.request_phone_call(params)
       user_id = params.delete(:id) || params.delete('id')

--- a/lib/authy/version.rb
+++ b/lib/authy/version.rb
@@ -1,3 +1,3 @@
 module Authy
-  VERSION = "2.7.2"
+  VERSION = "2.7.3"
 end


### PR DESCRIPTION
Hi guys. First of all, thank you for a decent SDK.

What I found out is that we lack a way of generating qr code for some authenticator app like Google Authenticator. It is well documented in the API docs so I thought I could implement it. https://www.twilio.com/docs/authy/api/one-time-passwords

Please take a look and consider this 😄 