### PR TITLE
Adds a deprecation warning that prints when you load the gem.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.0, head]
+        ruby: [2.5, 2.6, 2.7, "3.0", 3.1, head]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby }}

--- a/lib/authy.rb
+++ b/lib/authy.rb
@@ -12,3 +12,5 @@ require 'authy/config'
 require 'authy/api'
 require 'authy/phone_verification'
 require 'authy/onetouch'
+
+warn "DEPRECATION WARNING: The authy-ruby library is no longer actively maintained. The Authy API is being replaced by the Twilio Verify API. Please see the README for more details."

--- a/spec/authy/api_spec.rb
+++ b/spec/authy/api_spec.rb
@@ -337,7 +337,7 @@ describe "Authy::API" do
 
       expect(Authy::API.http_client).to receive(:request)
         .once
-        .with(:post, url, body: "", header: headers)
+        .with(:post, url, { body: "", header: headers })
         .and_return(double(ok?: true, body: response_json, status: 200))
       response = Authy::API.request_email(id: user_id)
       expect(response).to be_ok
@@ -405,9 +405,12 @@ describe "Authy::API" do
         new_email = generate_email
         expect(Authy::API.http_client).to receive(:request)
           .once
-          .with(:post, url, body: Utils.escape_query({
-            email: new_email
-          }), header: headers)
+          .with(:post, url, {
+            body: Utils.escape_query({
+              email: new_email
+            }),
+            header: headers
+          })
           .and_return(double(ok?: true, body: response_json, status: 200))
         response = Authy::API.update_user(id: user_id, email: new_email)
         expect(response.message).to eq "User was updated successfully"


### PR DESCRIPTION
This adds a deprecation warning when you load the gem. I was going to release a new version (3.0.1) of the gem so that RubyGems can pick up the [new description and summary](https://github.com/twilio/authy-ruby/blob/master/authy.gemspec#L12-L13), so I thought, while I'm at it, why not a deprecation message for those that update their gems.

@robinske do you think this is a good idea?

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
